### PR TITLE
Script Modules API: Move the script modules to the footer in classic themes

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -92,15 +92,12 @@ class WP_Script_Modules {
 				'version'      => $version,
 				'enqueue'      => isset( $this->enqueued_before_registered[ $id ] ),
 				'dependencies' => $dependencies,
-				'enqueued'     => false,
-				'preloaded'    => false,
 			);
 		}
 	}
 
 	/**
-	 * Marks the script module to be enqueued in the page the next time
-	 * `print_enqueued_script_modules` is called.
+	 * Marks the script module to be enqueued in the page.
 	 *
 	 * If a src is provided and the script module has not been registered yet, it
 	 * will be registered.
@@ -164,54 +161,34 @@ class WP_Script_Modules {
 	 * Adds the hooks to print the import map, enqueued script modules and script
 	 * module preloads.
 	 *
-	 * It adds the actions to print the enqueued script modules and script module
-	 * preloads to both `wp_head` and `wp_footer` because in classic themes, the
-	 * script modules used by the theme and plugins will likely be able to be
-	 * printed in the `head`, but the ones used by the blocks will need to be
-	 * enqueued in the `footer`.
-	 *
-	 * As all script modules are deferred and dependencies are handled by the
-	 * browser, the order of the script modules is not important, but it's still
-	 * better to print the ones that are available when the `wp_head` is rendered,
-	 * so the browser starts downloading those as soon as possible.
-	 *
-	 * The import map is also printed in the footer to be able to include the
-	 * dependencies of all the script modules, including the ones printed in the
+	 * In classic themes, the script modules used by the blocks are not yet known
+	 * when the `wp_head` actions is fired, so it needs to print everything in the
 	 * footer.
 	 *
 	 * @since 6.5.0
 	 */
 	public function add_hooks() {
-		add_action( 'wp_head', array( $this, 'print_enqueued_script_modules' ) );
-		add_action( 'wp_head', array( $this, 'print_script_module_preloads' ) );
-		add_action( 'wp_footer', array( $this, 'print_enqueued_script_modules' ) );
-		add_action( 'wp_footer', array( $this, 'print_script_module_preloads' ) );
-		add_action( 'wp_footer', array( $this, 'print_import_map' ) );
+		$position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
+		add_action( $position, array( $this, 'print_import_map' ) );
+		add_action( $position, array( $this, 'print_enqueued_modules' ) );
+		add_action( $position, array( $this, 'print_module_preloads' ) );
 	}
 
 	/**
 	 * Prints the enqueued script modules using script tags with type="module"
 	 * attributes.
 	 *
-	 * If a enqueued script module has already been printed, it will not be
-	 * printed again on subsequent calls to this function.
-	 *
 	 * @since 6.5.0
 	 */
 	public function print_enqueued_script_modules() {
 		foreach ( $this->get_marked_for_enqueue() as $id => $script_module ) {
-			if ( false === $script_module['enqueued'] ) {
-				// Mark it as enqueued so it doesn't get enqueued again.
-				$this->registered[ $id ]['enqueued'] = true;
-
-				wp_print_script_tag(
-					array(
-						'type' => 'module',
-						'src'  => $this->get_versioned_src( $script_module ),
-						'id'   => $id . '-js-module',
-					)
-				);
-			}
+			wp_print_script_tag(
+				array(
+					'type' => 'module',
+					'src'  => $this->get_versioned_src( $script_module ),
+					'id'   => $id . '-js-module',
+				)
+			);
 		}
 	}
 
@@ -219,19 +196,14 @@ class WP_Script_Modules {
 	 * Prints the the static dependencies of the enqueued script modules using
 	 * link tags with rel="modulepreload" attributes.
 	 *
-	 * If a script module is marked for enqueue, it will not be preloaded. If a
-	 * preloaded script module has already been printed, it will not be printed
-	 * again on subsequent calls to this function.
+	 * If a script module is marked for enqueue, it will not be preloaded.
 	 *
 	 * @since 6.5.0
 	 */
 	public function print_script_module_preloads() {
 		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ), array( 'static' ) ) as $id => $script_module ) {
-			// Don't preload if it's marked for enqueue or has already been preloaded.
-			if ( true !== $script_module['enqueue'] && false === $script_module['preloaded'] ) {
-				// Mark it as preloaded so it doesn't get preloaded again.
-				$this->registered[ $id ]['preloaded'] = true;
-
+			// Don't preload if it's marked for enqueue.
+			if ( true !== $script_module['enqueue'] ) {
 				echo sprintf(
 					'<link rel="modulepreload" href="%s" id="%s">',
 					esc_url( $this->get_versioned_src( $script_module ) ),

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -36,32 +36,27 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string                                                        $id      The identifier of the script module.
-	 *                                                                               Should be unique. It will be used
-	 *                                                                               in the final import map.
-	 * @param string                                                        $src     Full URL of the script module, or
-	 *                                                                               path of the script module relative
-	 *                                                                               to the WordPress root directory.
-	 * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
-	 *                                                                               identifiers of the dependencies of
-	 *                                                                               this script module. The
-	 *                                                                               dependencies can be strings or
-	 *                                                                               arrays. If they are arrays, they
-	 *                                                                               need an `id` key with the script
-	 *                                                                               module identifier, and can contain
-	 *                                                                               an `import` key with either
-	 *                                                                               `static` or `dynamic`. By default,
-	 *                                                                               dependencies that don't contain an
-	 *                                                                               `import` key are considered static.
-	 * @param string|false|null                                             $version Optional. String specifying the
-	 *                                                                               script module version number.
-	 *                                                                               Defaults to false. It is added to
-	 *                                                                               the URL as a query string for cache
-	 *                                                                               busting purposes. If $version is
-	 *                                                                               set to false, the version number is
-	 *                                                                               the currently installed WordPress
-	 *                                                                               version. If $version is set to
-	 *                                                                               null, no version is added.
+	 * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
+	 *                                    final import map.
+	 * @param string            $src      Full URL of the script module, or path of the script module relative to the
+	 *                                    WordPress root directory.
+	 * @param array             $deps     {
+	 *                                       Optional. List of dependencies.
+	 *                                       @type string|array $0... {
+	 *                                           An array of script module identifiers of the dependencies of this script
+	 *                                           module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                           they need an `id` key with the script module identifier, and can contain
+	 *                                           an `import` key with either `static` or `dynamic`. By default,
+	 *                                           dependencies that don't contain an `import` key are considered static.
+	 *                                           @type string $id     The script module identifier.
+	 *                                           @type string $import Optional. Import type. May be either `static` or
+	 *                                                                `dynamic`. Defaults to `static`.
+	 *                                       }
+	 *                                   }
+	 * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
+	 *                                   It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                   is set to false, the version number is the currently installed WordPress version.
+	 *                                   If $version is set to null, no version is added.
 	 */
 	public function register( $id, $src, $deps = array(), $version = false ) {
 		if ( ! isset( $this->registered[ $id ] ) ) {
@@ -106,35 +101,28 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string                                                        $id      The identifier of the script module.
-	 *                                                                               Should be unique. It will be used
-	 *                                                                               in the final import map.
-	 * @param string                                                        $src     Optional. Full URL of the script
-	 *                                                                               module, or path of the script module
-	 *                                                                               relative the WordPress root
-	 *                                                                               directory. If it is provided and the
-	 *                                                                               script module has not been registered
-	 *                                                                               yet, it will be registered.
-	 * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
-	 *                                                                               identifiers of the dependencies of
-	 *                                                                               this script module. The
-	 *                                                                               dependencies can be strings or
-	 *                                                                               arrays. If they are arrays, they
-	 *                                                                               need an `id` key with the script
-	 *                                                                               module identifier, and can contain
-	 *                                                                               an `import` key with either
-	 *                                                                               `static` or `dynamic`. By default,
-	 *                                                                               dependencies that don't contain an
-	 *                                                                               `import` key are considered static.
-	 * @param string|false|null                                             $version Optional. String specifying the
-	 *                                                                               script module version number.
-	 *                                                                               Defaults to false. It is added to
-	 *                                                                               the URL as a query string for cache
-	 *                                                                               busting purposes. If $version is
-	 *                                                                               set to false, the version number is
-	 *                                                                               the currently installed WordPress
-	 *                                                                               version. If $version is set to
-	 *                                                                               null, no version is added.
+	 * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
+	 *                                    final import map.
+	 * @param string            $src      Optinal. Full URL of the script module, or path of the script module relative to
+	 *                                    the WordPress root directory. If it is provided and the script module has not
+	 *                                    been registered yet, it will be registered.
+	 * @param array             $deps     {
+	 *                                       Optional. List of dependencies.
+	 *                                       @type string|array $0... {
+	 *                                           An array of script module identifiers of the dependencies of this script
+	 *                                           module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                           they need an `id` key with the script module identifier, and can contain
+	 *                                           an `import` key with either `static` or `dynamic`. By default,
+	 *                                           dependencies that don't contain an `import` key are considered static.
+	 *                                           @type string $id     The script module identifier.
+	 *                                           @type string $import Optional. Import type. May be either `static` or
+	 *                                                                `dynamic`. Defaults to `static`.
+	 *                                       }
+	 *                                   }
+	 * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
+	 *                                   It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                   is set to false, the version number is the currently installed WordPress version.
+	 *                                   If $version is set to null, no version is added.
 	 */
 	public function enqueue( $id, $src = '', $deps = array(), $version = false ) {
 		if ( isset( $this->registered[ $id ] ) ) {

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -38,25 +38,31 @@ class WP_Script_Modules {
 	 *
 	 * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
 	 *                                    final import map.
-	 * @param string            $src      Full URL of the script module, or path of the script module relative to the
-	 *                                    WordPress root directory.
-	 * @param array             $deps     {
-	 *                                       Optional. List of dependencies.
-	 *                                       @type string|array $0... {
-	 *                                           An array of script module identifiers of the dependencies of this script
-	 *                                           module. The dependencies can be strings or arrays. If they are arrays,
-	 *                                           they need an `id` key with the script module identifier, and can contain
-	 *                                           an `import` key with either `static` or `dynamic`. By default,
-	 *                                           dependencies that don't contain an `import` key are considered static.
-	 *                                           @type string $id     The script module identifier.
-	 *                                           @type string $import Optional. Import type. May be either `static` or
-	 *                                                                `dynamic`. Defaults to `static`.
-	 *                                       }
-	 *                                   }
-	 * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
-	 *                                   It is added to the URL as a query string for cache busting purposes. If $version
-	 *                                   is set to false, the version number is the currently installed WordPress version.
-	 *                                   If $version is set to null, no version is added.
+	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
+	 *                                    to the WordPress root directory. If it is provided and the script module has
+	 *                                    not been registered yet, it will be registered.
+	 * @param array<string|array{
+	 *            id: string,
+	 *            import?: 'static'|'dynamic'
+	 *        }>                $deps     {
+	 *                                        Optional. List of dependencies.
+	 *
+	 *                                        @type string|array $0... {
+	 *                                            An array of script module identifiers of the dependencies of this script
+	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                            they need an `id` key with the script module identifier, and can contain
+	 *                                            an `import` key with either `static` or `dynamic`. By default,
+	 *                                            dependencies that don't contain an `import` key are considered static.
+	 *
+	 *                                            @type string $id     The script module identifier.
+	 *                                            @type string $import Optional. Import type. May be either `static` or
+	 *                                                                 `dynamic`. Defaults to `static`.
+	 *                                        }
+	 *                                    }
+	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
+	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                    is set to false, the version number is the currently installed WordPress version.
+	 *                                    If $version is set to null, no version is added.
 	 */
 	public function register( string $id, string $src, array $deps = array(), $version = false ) {
 		if ( ! isset( $this->registered[ $id ] ) ) {

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Modules API: WP_Script_Modules class.
+ * Script Modules API: WP_Script_Modules class.
  *
  * Native support for ES Modules and Import Maps.
  *
@@ -9,13 +9,13 @@
  */
 
 /**
- * Core class used to register modules.
+ * Core class used to register script modules.
  *
  * @since 6.5.0
  */
 class WP_Script_Modules {
 	/**
-	 * Holds the registered modules, keyed by module identifier.
+	 * Holds the registered script modules, keyed by script module identifier.
 	 *
 	 * @since 6.5.0
 	 * @var array
@@ -23,7 +23,7 @@ class WP_Script_Modules {
 	private $registered = array();
 
 	/**
-	 * Holds the module identifiers that were enqueued before registered.
+	 * Holds the script module identifiers that were enqueued before registered.
 	 *
 	 * @since 6.5.0
 	 * @var array
@@ -31,39 +31,40 @@ class WP_Script_Modules {
 	private $enqueued_before_registered = array();
 
 	/**
-	 * Registers the module if no module with that module identifier has already
-	 * been registered.
+	 * Registers the script module if no script module with that script module
+	 * identifier has already been registered.
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string                                                        $module_id The identifier of the module.
-	 *                                                                                 Should be unique. It will be used
-	 *                                                                                 in the final import map.
-	 * @param string                                                        $src       Full URL of the module, or path of
-	 *                                                                                 the module relative to the
-	 *                                                                                 WordPress root directory.
-	 * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps      Optional. An array of module
-	 *                                                                                 identifiers of the dependencies of
-	 *                                                                                 this module. The dependencies can
-	 *                                                                                 be strings or arrays. If they are
-	 *                                                                                 arrays, they need an `id` key with
-	 *                                                                                 the module identifier, and can
-	 *                                                                                 contain an `import` key with either
-	 *                                                                                 `static` or `dynamic`. By default,
-	 *                                                                                 dependencies that don't contain an
-	 *                                                                                 `import` key are considered static.
-	 * @param string|false|null                                             $version   Optional. String specifying the
-	 *                                                                                 module version number. Defaults to
-	 *                                                                                 false. It is added to the URL as a
-	 *                                                                                 query string for cache busting
-	 *                                                                                 purposes. If $version is set to
-	 *                                                                                 false, the version number is the
-	 *                                                                                 currently installed WordPress
-	 *                                                                                 version. If $version is set to
-	 *                                                                                 null, no version is added.
+	 * @param string                                                        $id      The identifier of the script module.
+	 *                                                                               Should be unique. It will be used
+	 *                                                                               in the final import map.
+	 * @param string                                                        $src     Full URL of the script module, or
+	 *                                                                               path of the script module relative
+	 *                                                                               to the WordPress root directory.
+	 * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
+	 *                                                                               identifiers of the dependencies of
+	 *                                                                               this script module. The
+	 *                                                                               dependencies can be strings or
+	 *                                                                               arrays. If they are arrays, they
+	 *                                                                               need an `id` key with the script
+	 *                                                                               module identifier, and can contain
+	 *                                                                               an `import` key with either
+	 *                                                                               `static` or `dynamic`. By default,
+	 *                                                                               dependencies that don't contain an
+	 *                                                                               `import` key are considered static.
+	 * @param string|false|null                                             $version Optional. String specifying the
+	 *                                                                               script module version number.
+	 *                                                                               Defaults to false. It is added to
+	 *                                                                               the URL as a query string for cache
+	 *                                                                               busting purposes. If $version is
+	 *                                                                               set to false, the version number is
+	 *                                                                               the currently installed WordPress
+	 *                                                                               version. If $version is set to
+	 *                                                                               null, no version is added.
 	 */
-	public function register( $module_id, $src, $deps = array(), $version = false ) {
-		if ( ! isset( $this->registered[ $module_id ] ) ) {
+	public function register( $id, $src, $deps = array(), $version = false ) {
+		if ( ! isset( $this->registered[ $id ] ) ) {
 			$dependencies = array();
 			foreach ( $deps as $dependency ) {
 				if ( is_array( $dependency ) ) {
@@ -85,10 +86,10 @@ class WP_Script_Modules {
 				}
 			}
 
-			$this->registered[ $module_id ] = array(
+			$this->registered[ $id ] = array(
 				'src'          => $src,
 				'version'      => $version,
-				'enqueue'      => isset( $this->enqueued_before_registered[ $module_id ] ),
+				'enqueue'      => isset( $this->enqueued_before_registered[ $id ] ),
 				'dependencies' => $dependencies,
 				'enqueued'     => false,
 				'preloaded'    => false,
@@ -97,116 +98,118 @@ class WP_Script_Modules {
 	}
 
 	/**
-	 * Marks the module to be enqueued in the page the next time
-	 * `prints_enqueued_modules` is called.
+	 * Marks the script module to be enqueued in the page the next time
+	 * `print_enqueued_script_modules` is called.
 	 *
-	 * If a src is provided and the module has not been registered yet, it will be
-	 * registered.
+	 * If a src is provided and the script module has not been registered yet, it
+	 * will be registered.
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string                                                        $module_id The identifier of the module.
-	 *                                                                                 Should be unique. It will be used
-	 *                                                                                 in the final import map.
-	 * @param string                                                        $src       Optional. Full URL of the module,
-	 *                                                                                 or path of the module relative to
-	 *                                                                                 the WordPress root directory. If
-	 *                                                                                 it is provided and the module has
-	 *                                                                                 not been registered yet, it will be
-	 *                                                                                 registered.
-	 * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps      Optional. An array of module
-	 *                                                                                 identifiers of the dependencies of
-	 *                                                                                 this module. The dependencies can
-	 *                                                                                 be strings or arrays. If they are
-	 *                                                                                 arrays, they need an `id` key with
-	 *                                                                                 the module identifier, and can
-	 *                                                                                 contain an `import` key with either
-	 *                                                                                 `static` or `dynamic`. By default,
-	 *                                                                                 dependencies that don't contain an
-	 *                                                                                 `import` key are considered static.
-	 * @param string|false|null                                             $version   Optional. String specifying the
-	 *                                                                                 module version number. Defaults to
-	 *                                                                                 false. It is added to the URL as a
-	 *                                                                                 query string for cache busting
-	 *                                                                                 purposes. If $version is set to
-	 *                                                                                 false, the version number is the
-	 *                                                                                 currently installed WordPress
-	 *                                                                                 version. If $version is set to
-	 *                                                                                 null, no version is added.
+	 * @param string                                                        $id      The identifier of the script module.
+	 *                                                                               Should be unique. It will be used
+	 *                                                                               in the final import map.
+	 * @param string                                                        $src     Optional. Full URL of the script
+	 *                                                                               module, or path of the script module
+	 *                                                                               relative the WordPress root
+	 *                                                                               directory. If it is provided and the
+	 *                                                                               script module has not been registered
+	 *                                                                               yet, it will be registered.
+	 * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
+	 *                                                                               identifiers of the dependencies of
+	 *                                                                               this script module. The
+	 *                                                                               dependencies can be strings or
+	 *                                                                               arrays. If they are arrays, they
+	 *                                                                               need an `id` key with the script
+	 *                                                                               module identifier, and can contain
+	 *                                                                               an `import` key with either
+	 *                                                                               `static` or `dynamic`. By default,
+	 *                                                                               dependencies that don't contain an
+	 *                                                                               `import` key are considered static.
+	 * @param string|false|null                                             $version Optional. String specifying the
+	 *                                                                               script module version number.
+	 *                                                                               Defaults to false. It is added to
+	 *                                                                               the URL as a query string for cache
+	 *                                                                               busting purposes. If $version is
+	 *                                                                               set to false, the version number is
+	 *                                                                               the currently installed WordPress
+	 *                                                                               version. If $version is set to
+	 *                                                                               null, no version is added.
 	 */
-	public function enqueue( $module_id, $src = '', $deps = array(), $version = false ) {
-		if ( isset( $this->registered[ $module_id ] ) ) {
-			$this->registered[ $module_id ]['enqueue'] = true;
+	public function enqueue( $id, $src = '', $deps = array(), $version = false ) {
+		if ( isset( $this->registered[ $id ] ) ) {
+			$this->registered[ $id ]['enqueue'] = true;
 		} elseif ( $src ) {
-			$this->register( $module_id, $src, $deps, $version );
-			$this->registered[ $module_id ]['enqueue'] = true;
+			$this->register( $id, $src, $deps, $version );
+			$this->registered[ $id ]['enqueue'] = true;
 		} else {
-			$this->enqueued_before_registered[ $module_id ] = true;
+			$this->enqueued_before_registered[ $id ] = true;
 		}
 	}
 
 	/**
-	 * Unmarks the module so it will no longer be enqueued in the page.
+	 * Unmarks the script module so it will no longer be enqueued in the page.
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string $module_id The identifier of the module.
+	 * @param string $id The identifier of the script module.
 	 */
-	public function dequeue( $module_id ) {
-		if ( isset( $this->registered[ $module_id ] ) ) {
-			$this->registered[ $module_id ]['enqueue'] = false;
+	public function dequeue( $id ) {
+		if ( isset( $this->registered[ $id ] ) ) {
+			$this->registered[ $id ]['enqueue'] = false;
 		}
-		unset( $this->enqueued_before_registered[ $module_id ] );
+		unset( $this->enqueued_before_registered[ $id ] );
 	}
 
 	/**
-	 * Adds the hooks to print the import map, enqueued modules and module
-	 * preloads.
+	 * Adds the hooks to print the import map, enqueued script modules and script
+	 * module preloads.
 	 *
-	 * It adds the actions to print the enqueued modules and module preloads to
-	 * both `wp_head` and `wp_footer` because in classic themes, the modules
-	 * used by the theme and plugins will likely be able to be printed in the
-	 * `head`, but the ones used by the blocks will need to be enqueued in the
-	 * `footer`.
+	 * It adds the actions to print the enqueued script modules and script module
+	 * preloads to both `wp_head` and `wp_footer` because in classic themes, the
+	 * script modules used by the theme and plugins will likely be able to be
+	 * printed in the `head`, but the ones used by the blocks will need to be
+	 * enqueued in the `footer`.
 	 *
-	 * As all modules are deferred and dependencies are handled by the browser,
-	 * the order of the modules is not important, but it's still better to print
-	 * the ones that are available when the `wp_head` is rendered, so the browser
-	 * starts downloading those as soon as possible.
+	 * As all script modules are deferred and dependencies are handled by the
+	 * browser, the order of the script modules is not important, but it's still
+	 * better to print the ones that are available when the `wp_head` is rendered,
+	 * so the browser starts downloading those as soon as possible.
 	 *
 	 * The import map is also printed in the footer to be able to include the
-	 * dependencies of all the modules, including the ones printed in the footer.
+	 * dependencies of all the script modules, including the ones printed in the
+	 * footer.
 	 *
 	 * @since 6.5.0
 	 */
 	public function add_hooks() {
-		add_action( 'wp_head', array( $this, 'print_enqueued_modules' ) );
-		add_action( 'wp_head', array( $this, 'print_module_preloads' ) );
-		add_action( 'wp_footer', array( $this, 'print_enqueued_modules' ) );
-		add_action( 'wp_footer', array( $this, 'print_module_preloads' ) );
+		add_action( 'wp_head', array( $this, 'print_enqueued_script_modules' ) );
+		add_action( 'wp_head', array( $this, 'print_script_module_preloads' ) );
+		add_action( 'wp_footer', array( $this, 'print_enqueued_script_modules' ) );
+		add_action( 'wp_footer', array( $this, 'print_script_module_preloads' ) );
 		add_action( 'wp_footer', array( $this, 'print_import_map' ) );
 	}
 
 	/**
-	 * Prints the enqueued modules using script tags with type="module"
+	 * Prints the enqueued script modules using script tags with type="module"
 	 * attributes.
 	 *
-	 * If a enqueued module has already been printed, it will not be printed again
-	 * on subsequent calls to this function.
+	 * If a enqueued script module has already been printed, it will not be
+	 * printed again on subsequent calls to this function.
 	 *
 	 * @since 6.5.0
 	 */
-	public function print_enqueued_modules() {
-		foreach ( $this->get_marked_for_enqueue() as $module_id => $module ) {
-			if ( false === $module['enqueued'] ) {
+	public function print_enqueued_script_modules() {
+		foreach ( $this->get_marked_for_enqueue() as $id => $script_module ) {
+			if ( false === $script_module['enqueued'] ) {
 				// Mark it as enqueued so it doesn't get enqueued again.
-				$this->registered[ $module_id ]['enqueued'] = true;
+				$this->registered[ $id ]['enqueued'] = true;
 
 				wp_print_script_tag(
 					array(
 						'type' => 'module',
-						'src'  => $this->get_versioned_src( $module ),
-						'id'   => $module_id . '-js-module',
+						'src'  => $this->get_versioned_src( $script_module ),
+						'id'   => $id . '-js-module',
 					)
 				);
 			}
@@ -214,26 +217,26 @@ class WP_Script_Modules {
 	}
 
 	/**
-	 * Prints the the static dependencies of the enqueued modules using link tags
-	 * with rel="modulepreload" attributes.
+	 * Prints the the static dependencies of the enqueued script modules using
+	 * link tags with rel="modulepreload" attributes.
 	 *
-	 * If a module is marked for enqueue, it will not be preloaded. If a preloaded
-	 * module has already been printed, it will not be printed again on subsequent
-	 * calls to this function.
+	 * If a script module is marked for enqueue, it will not be preloaded. If a
+	 * preloaded script module has already been printed, it will not be printed
+	 * again on subsequent calls to this function.
 	 *
 	 * @since 6.5.0
 	 */
-	public function print_module_preloads() {
-		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ), array( 'static' ) ) as $module_id => $module ) {
+	public function print_script_module_preloads() {
+		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ), array( 'static' ) ) as $id => $script_module ) {
 			// Don't preload if it's marked for enqueue or has already been preloaded.
-			if ( true !== $module['enqueue'] && false === $module['preloaded'] ) {
+			if ( true !== $script_module['enqueue'] && false === $script_module['preloaded'] ) {
 				// Mark it as preloaded so it doesn't get preloaded again.
-				$this->registered[ $module_id ]['preloaded'] = true;
+				$this->registered[ $id ]['preloaded'] = true;
 
 				echo sprintf(
 					'<link rel="modulepreload" href="%s" id="%s">',
-					esc_url( $this->get_versioned_src( $module ) ),
-					esc_attr( $module_id . '-js-modulepreload' )
+					esc_url( $this->get_versioned_src( $script_module ) ),
+					esc_attr( $id . '-js-modulepreload' )
 				);
 			}
 		}
@@ -262,37 +265,37 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return array Array with an `imports` key mapping to an array of module identifiers and their respective URLs,
-	 *               including the version query.
+	 * @return array Array with an `imports` key mapping to an array of script module identifiers and their respective
+	 *               URLs, including the version query.
 	 */
 	private function get_import_map() {
 		$imports = array();
-		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ) ) as $module_id => $module ) {
-			$imports[ $module_id ] = $this->get_versioned_src( $module );
+		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ) ) as $id => $script_module ) {
+			$imports[ $id ] = $this->get_versioned_src( $script_module );
 		}
 		return array( 'imports' => $imports );
 	}
 
 	/**
-	 * Retrieves the list of modules marked for enqueue.
+	 * Retrieves the list of script modules marked for enqueue.
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return array Modules marked for enqueue, keyed by module identifier.
+	 * @return array Script modules marked for enqueue, keyed by script module identifier.
 	 */
 	private function get_marked_for_enqueue() {
 		$enqueued = array();
-		foreach ( $this->registered as $module_id => $module ) {
-			if ( true === $module['enqueue'] ) {
-				$enqueued[ $module_id ] = $module;
+		foreach ( $this->registered as $id => $script_module ) {
+			if ( true === $script_module['enqueue'] ) {
+				$enqueued[ $id ] = $script_module;
 			}
 		}
 		return $enqueued;
 	}
 
 	/**
-	 * Retrieves all the dependencies for the given module identifiers, filtered
-	 * by import types.
+	 * Retrieves all the dependencies for the given script module identifiers,
+	 * filtered by import types.
 	 *
 	 * It will consolidate an array containing a set of unique dependencies based
 	 * on the requested import types: 'static', 'dynamic', or both. This method is
@@ -300,33 +303,33 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param array $module_ids   The identifiers of the modules for which to gather dependencies.
+	 * @param array $ids          The identifiers of the script modules for which to gather dependencies.
 	 * @param array $import_types Optional. Import types of dependencies to retrieve: 'static', 'dynamic', or both.
 	 *                            Default is both.
-	 * @return array List of dependencies, keyed by module identifier.
+	 * @return array List of dependencies, keyed by script module identifier.
 	 */
-	private function get_dependencies( $module_ids, $import_types = array( 'static', 'dynamic' ) ) {
+	private function get_dependencies( $ids, $import_types = array( 'static', 'dynamic' ) ) {
 		return array_reduce(
-			$module_ids,
-			function ( $dependency_modules, $module_id ) use ( $import_types ) {
+			$ids,
+			function ( $dependency_script_modules, $id ) use ( $import_types ) {
 				$dependencies = array();
-				foreach ( $this->registered[ $module_id ]['dependencies'] as $dependency ) {
+				foreach ( $this->registered[ $id ]['dependencies'] as $dependency ) {
 					if (
 					in_array( $dependency['import'], $import_types, true ) &&
 					isset( $this->registered[ $dependency['id'] ] ) &&
-					! isset( $dependency_modules[ $dependency['id'] ] )
+					! isset( $dependency_script_modules[ $dependency['id'] ] )
 					) {
 						$dependencies[ $dependency['id'] ] = $this->registered[ $dependency['id'] ];
 					}
 				}
-				return array_merge( $dependency_modules, $dependencies, $this->get_dependencies( array_keys( $dependencies ), $import_types ) );
+				return array_merge( $dependency_script_modules, $dependencies, $this->get_dependencies( array_keys( $dependencies ), $import_types ) );
 			},
 			array()
 		);
 	}
 
 	/**
-	 * Gets the versioned URL for a module src.
+	 * Gets the versioned URL for a script module src.
 	 *
 	 * If $version is set to false, the version number is the currently installed
 	 * WordPress version. If $version is set to null, no version is added.
@@ -334,19 +337,19 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param array $module The module.
-	 * @return string The module src with a version if relevant.
+	 * @param array $script_module The script module.
+	 * @return string The script module src with a version if relevant.
 	 */
-	private function get_versioned_src( array $module ) {
+	private function get_versioned_src( array $script_module ) {
 		$args = array();
-		if ( false === $module['version'] ) {
+		if ( false === $script_module['version'] ) {
 			$args['ver'] = get_bloginfo( 'version' );
-		} elseif ( null !== $module['version'] ) {
-			$args['ver'] = $module['version'];
+		} elseif ( null !== $script_module['version'] ) {
+			$args['ver'] = $script_module['version'];
 		}
 		if ( $args ) {
-			return add_query_arg( $args, $module['src'] );
+			return add_query_arg( $args, $script_module['src'] );
 		}
-		return $module['src'];
+		return $script_module['src'];
 	}
 }

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -33,32 +33,27 @@ function wp_script_modules() {
  *
  * @since 6.5.0
  *
- * @param string                                                        $id      The identifier of the script module.
- *                                                                               Should be unique. It will be used
- *                                                                               in the final import map.
- * @param string                                                        $src     Full URL of the script module, or
- *                                                                               path of the script module relative
- *                                                                               to the WordPress root directory.
- * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
- *                                                                               identifiers of the dependencies of
- *                                                                               this script module. The
- *                                                                               dependencies can be strings or
- *                                                                               arrays. If they are arrays, they
- *                                                                               need an `id` key with the script
- *                                                                               module identifier, and can contain
- *                                                                               an `import` key with either
- *                                                                               `static` or `dynamic`. By default,
- *                                                                               dependencies that don't contain an
- *                                                                               `import` key are considered static.
- * @param string|false|null                                             $version Optional. String specifying the
- *                                                                               script module version number.
- *                                                                               Defaults to false. It is added to
- *                                                                               the URL as a query string for cache
- *                                                                               busting purposes. If $version is
- *                                                                               set to false, the version number is
- *                                                                               the currently installed WordPress
- *                                                                               version. If $version is set to
- *                                                                               null, no version is added.
+ * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
+ *                                    final import map.
+ * @param string            $src      Full URL of the script module, or path of the script module relative to the
+ *                                    WordPress root directory.
+ * @param array             $deps     {
+ *                                       Optional. List of dependencies.
+ *                                       @type string|array $0... {
+ *                                           An array of script module identifiers of the dependencies of this script
+ *                                           module. The dependencies can be strings or arrays. If they are arrays,
+ *                                           they need an `id` key with the script module identifier, and can contain
+ *                                           an `import` key with either `static` or `dynamic`. By default,
+ *                                           dependencies that don't contain an `import` key are considered static.
+ *                                           @type string $id     The script module identifier.
+ *                                           @type string $import Optional. Import type. May be either `static` or
+ *                                                                `dynamic`. Defaults to `static`.
+ *                                       }
+ *                                   }
+ * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
+ *                                   It is added to the URL as a query string for cache busting purposes. If $version
+ *                                   is set to false, the version number is the currently installed WordPress version.
+ *                                   If $version is set to null, no version is added.
  */
 function wp_register_script_module( $id, $src, $deps = array(), $version = false ) {
 	wp_script_modules()->register( $id, $src, $deps, $version );
@@ -72,35 +67,28 @@ function wp_register_script_module( $id, $src, $deps = array(), $version = false
  *
  * @since 6.5.0
  *
- * @param string                                                        $id      The identifier of the script module.
- *                                                                               Should be unique. It will be used
- *                                                                               in the final import map.
- * @param string                                                        $src     Optional. Full URL of the script
- *                                                                               module, or path of the script module
- *                                                                               relative the WordPress root
- *                                                                               directory. If it is provided and the
- *                                                                               script module has not been registered
- *                                                                               yet, it will be registered.
- * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
- *                                                                               identifiers of the dependencies of
- *                                                                               this script module. The
- *                                                                               dependencies can be strings or
- *                                                                               arrays. If they are arrays, they
- *                                                                               need an `id` key with the script
- *                                                                               module identifier, and can contain
- *                                                                               an `import` key with either
- *                                                                               `static` or `dynamic`. By default,
- *                                                                               dependencies that don't contain an
- *                                                                               `import` key are considered static.
- * @param string|false|null                                             $version Optional. String specifying the
- *                                                                               script module version number.
- *                                                                               Defaults to false. It is added to
- *                                                                               the URL as a query string for cache
- *                                                                               busting purposes. If $version is
- *                                                                               set to false, the version number is
- *                                                                               the currently installed WordPress
- *                                                                               version. If $version is set to
- *                                                                               null, no version is added.
+ * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
+ *                                    final import map.
+ * @param string            $src      Optinal. Full URL of the script module, or path of the script module relative to
+ *                                    the WordPress root directory. If it is provided and the script module has not
+ *                                    been registered yet, it will be registered.
+ * @param array             $deps     {
+ *                                       Optional. List of dependencies.
+ *                                       @type string|array $0... {
+ *                                           An array of script module identifiers of the dependencies of this script
+ *                                           module. The dependencies can be strings or arrays. If they are arrays,
+ *                                           they need an `id` key with the script module identifier, and can contain
+ *                                           an `import` key with either `static` or `dynamic`. By default,
+ *                                           dependencies that don't contain an `import` key are considered static.
+ *                                           @type string $id     The script module identifier.
+ *                                           @type string $import Optional. Import type. May be either `static` or
+ *                                                                `dynamic`. Defaults to `static`.
+ *                                       }
+ *                                   }
+ * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
+ *                                   It is added to the URL as a query string for cache busting purposes. If $version
+ *                                   is set to false, the version number is the currently installed WordPress version.
+ *                                   If $version is set to null, no version is added.
  */
 function wp_enqueue_script_module( $id, $src = '', $deps = array(), $version = false ) {
 	wp_script_modules()->enqueue( $id, $src, $deps, $version );

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Script Modules API: Module functions
+ * Script Modules API: Script Module functions
  *
  * @since 6.5.0
  *
@@ -28,89 +28,91 @@ function wp_script_modules() {
 }
 
 /**
- * Registers the module if no module with that module identifier has already
- * been registered.
+ * Registers the script module if no script module with that script module
+ * identifier has already been registered.
  *
  * @since 6.5.0
  *
- * @param string                                                        $module_id The identifier of the module.
- *                                                                                 Should be unique. It will be used
- *                                                                                 in the final import map.
- * @param string                                                        $src       Full URL of the module, or path of
- *                                                                                 the module relative to the
- *                                                                                 WordPress root directory.
- * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps      Optional. An array of module
- *                                                                                 identifiers of the dependencies of
- *                                                                                 this module. The dependencies can
- *                                                                                 be strings or arrays. If they are
- *                                                                                 arrays, they need an `id` key with
- *                                                                                 the module identifier, and can
- *                                                                                 contain an `import` key with either
- *                                                                                 `static` or `dynamic`. By default,
- *                                                                                 dependencies that don't contain an
- *                                                                                 `import` key are considered static.
- * @param string|false|null                                             $version   Optional. String specifying the
- *                                                                                 module version number. Defaults to
- *                                                                                 false. It is added to the URL as a
- *                                                                                 query string for cache busting
- *                                                                                 purposes. If $version is set to
- *                                                                                 false, the version number is the
- *                                                                                 currently installed WordPress
- *                                                                                 version. If $version is set to
- *                                                                                 null, no version is added.
+ * @param string                                                        $id      The identifier of the script module.
+ *                                                                               Should be unique. It will be used
+ *                                                                               in the final import map.
+ * @param string                                                        $src     Full URL of the script module, or
+ *                                                                               path of the script module relative
+ *                                                                               to the WordPress root directory.
+ * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
+ *                                                                               identifiers of the dependencies of
+ *                                                                               this script module. The
+ *                                                                               dependencies can be strings or
+ *                                                                               arrays. If they are arrays, they
+ *                                                                               need an `id` key with the script
+ *                                                                               module identifier, and can contain
+ *                                                                               an `import` key with either
+ *                                                                               `static` or `dynamic`. By default,
+ *                                                                               dependencies that don't contain an
+ *                                                                               `import` key are considered static.
+ * @param string|false|null                                             $version Optional. String specifying the
+ *                                                                               script module version number.
+ *                                                                               Defaults to false. It is added to
+ *                                                                               the URL as a query string for cache
+ *                                                                               busting purposes. If $version is
+ *                                                                               set to false, the version number is
+ *                                                                               the currently installed WordPress
+ *                                                                               version. If $version is set to
+ *                                                                               null, no version is added.
  */
-function wp_register_script_module( $module_id, $src, $deps = array(), $version = false ) {
-	wp_script_modules()->register( $module_id, $src, $deps, $version );
+function wp_register_script_module( $id, $src, $deps = array(), $version = false ) {
+	wp_script_modules()->register( $id, $src, $deps, $version );
 }
 
 /**
- * Marks the module to be enqueued in the page.
+ * Marks the script module to be enqueued in the page.
  *
- * If a src is provided and the module has not been registered yet, it will be
- * registered.
+ * If a src is provided and the script module has not been registered yet, it
+ * will be registered.
  *
  * @since 6.5.0
  *
- * @param string                                                        $module_id The identifier of the module.
- *                                                                                 Should be unique. It will be used
- *                                                                                 in the final import map.
- * @param string                                                        $src       Optional. Full URL of the module,
- *                                                                                 or path of the module relative to
- *                                                                                 the WordPress root directory. If
- *                                                                                 it is provided and the module has
- *                                                                                 not been registered yet, it will be
- *                                                                                 registered.
- * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps      Optional. An array of module
- *                                                                                 identifiers of the dependencies of
- *                                                                                 this module. The dependencies can
- *                                                                                 be strings or arrays. If they are
- *                                                                                 arrays, they need an `id` key with
- *                                                                                 the module identifier, and can
- *                                                                                 contain an `import` key with either
- *                                                                                 `static` or `dynamic`. By default,
- *                                                                                 dependencies that don't contain an
- *                                                                                 `import` key are considered static.
- * @param string|false|null                                             $version   Optional. String specifying the
- *                                                                                 module version number. Defaults to
- *                                                                                 false. It is added to the URL as a
- *                                                                                 query string for cache busting
- *                                                                                 purposes. If $version is set to
- *                                                                                 false, the version number is the
- *                                                                                 currently installed WordPress
- *                                                                                 version. If $version is set to
- *                                                                                 null, no version is added.
+ * @param string                                                        $id      The identifier of the script module.
+ *                                                                               Should be unique. It will be used
+ *                                                                               in the final import map.
+ * @param string                                                        $src     Optional. Full URL of the script
+ *                                                                               module, or path of the script module
+ *                                                                               relative the WordPress root
+ *                                                                               directory. If it is provided and the
+ *                                                                               script module has not been registered
+ *                                                                               yet, it will be registered.
+ * @param array<string|array{id: string, import?: 'static'|'dynamic' }> $deps    Optional. An array of script module
+ *                                                                               identifiers of the dependencies of
+ *                                                                               this script module. The
+ *                                                                               dependencies can be strings or
+ *                                                                               arrays. If they are arrays, they
+ *                                                                               need an `id` key with the script
+ *                                                                               module identifier, and can contain
+ *                                                                               an `import` key with either
+ *                                                                               `static` or `dynamic`. By default,
+ *                                                                               dependencies that don't contain an
+ *                                                                               `import` key are considered static.
+ * @param string|false|null                                             $version Optional. String specifying the
+ *                                                                               script module version number.
+ *                                                                               Defaults to false. It is added to
+ *                                                                               the URL as a query string for cache
+ *                                                                               busting purposes. If $version is
+ *                                                                               set to false, the version number is
+ *                                                                               the currently installed WordPress
+ *                                                                               version. If $version is set to
+ *                                                                               null, no version is added.
  */
-function wp_enqueue_script_module( $module_id, $src = '', $deps = array(), $version = false ) {
-	wp_script_modules()->enqueue( $module_id, $src, $deps, $version );
+function wp_enqueue_script_module( $id, $src = '', $deps = array(), $version = false ) {
+	wp_script_modules()->enqueue( $id, $src, $deps, $version );
 }
 
 /**
- * Unmarks the module so it is no longer enqueued in the page.
+ * Unmarks the script module so it is no longer enqueued in the page.
  *
  * @since 6.5.0
  *
- * @param string $module_id The identifier of the module.
+ * @param string $id The identifier of the script module.
  */
-function wp_dequeue_script_module( $module_id ) {
-	wp_script_modules()->dequeue( $module_id );
+function wp_dequeue_script_module( $id ) {
+	wp_script_modules()->dequeue( $id );
 }

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -18,7 +18,7 @@
  *
  * @return WP_Script_Modules The main WP_Script_Modules instance.
  */
-function wp_modules() {
+function wp_script_modules() {
 	static $instance = null;
 	if ( is_null( $instance ) ) {
 		$instance = new WP_Script_Modules();
@@ -59,8 +59,8 @@ function wp_modules() {
  *                                                                                 version. If $version is set to
  *                                                                                 null, no version is added.
  */
-function wp_register_module( $module_id, $src, $deps = array(), $version = false ) {
-	wp_modules()->register( $module_id, $src, $deps, $version );
+function wp_register_script_module( $module_id, $src, $deps = array(), $version = false ) {
+	wp_script_modules()->register( $module_id, $src, $deps, $version );
 }
 
 /**
@@ -100,8 +100,8 @@ function wp_register_module( $module_id, $src, $deps = array(), $version = false
  *                                                                                 version. If $version is set to
  *                                                                                 null, no version is added.
  */
-function wp_enqueue_module( $module_id, $src = '', $deps = array(), $version = false ) {
-	wp_modules()->enqueue( $module_id, $src, $deps, $version );
+function wp_enqueue_script_module( $module_id, $src = '', $deps = array(), $version = false ) {
+	wp_script_modules()->enqueue( $module_id, $src, $deps, $version );
 }
 
 /**
@@ -111,6 +111,6 @@ function wp_enqueue_module( $module_id, $src = '', $deps = array(), $version = f
  *
  * @param string $module_id The identifier of the module.
  */
-function wp_dequeue_module( $module_id ) {
-	wp_modules()->dequeue( $module_id );
+function wp_dequeue_script_module( $module_id ) {
+	wp_script_modules()->dequeue( $module_id );
 }

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -18,7 +18,7 @@
  *
  * @return WP_Script_Modules The main WP_Script_Modules instance.
  */
-function wp_script_modules() {
+function wp_script_modules(): WP_Script_Modules {
 	static $instance = null;
 	if ( is_null( $instance ) ) {
 		$instance = new WP_Script_Modules();
@@ -35,27 +35,33 @@ function wp_script_modules() {
  *
  * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
  *                                    final import map.
- * @param string            $src      Full URL of the script module, or path of the script module relative to the
- *                                    WordPress root directory.
- * @param array             $deps     {
- *                                       Optional. List of dependencies.
- *                                       @type string|array $0... {
- *                                           An array of script module identifiers of the dependencies of this script
- *                                           module. The dependencies can be strings or arrays. If they are arrays,
- *                                           they need an `id` key with the script module identifier, and can contain
- *                                           an `import` key with either `static` or `dynamic`. By default,
- *                                           dependencies that don't contain an `import` key are considered static.
- *                                           @type string $id     The script module identifier.
- *                                           @type string $import Optional. Import type. May be either `static` or
- *                                                                `dynamic`. Defaults to `static`.
- *                                       }
- *                                   }
- * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
- *                                   It is added to the URL as a query string for cache busting purposes. If $version
- *                                   is set to false, the version number is the currently installed WordPress version.
- *                                   If $version is set to null, no version is added.
+	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
+	 *                                    to the WordPress root directory. If it is provided and the script module has
+	 *                                    not been registered yet, it will be registered.
+	 * @param array<string|array{
+	 *            id: string,
+	 *            import?: 'static'|'dynamic'
+	 *        }>                $deps     {
+	 *                                        Optional. List of dependencies.
+	 *
+	 *                                        @type string|array $0... {
+	 *                                            An array of script module identifiers of the dependencies of this script
+	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                            they need an `id` key with the script module identifier, and can contain
+	 *                                            an `import` key with either `static` or `dynamic`. By default,
+	 *                                            dependencies that don't contain an `import` key are considered static.
+	 *
+	 *                                            @type string $id     The script module identifier.
+	 *                                            @type string $import Optional. Import type. May be either `static` or
+	 *                                                                 `dynamic`. Defaults to `static`.
+	 *                                        }
+	 *                                    }
+	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
+	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                    is set to false, the version number is the currently installed WordPress version.
+	 *                                    If $version is set to null, no version is added.
  */
-function wp_register_script_module( $id, $src, $deps = array(), $version = false ) {
+function wp_register_script_module( string $id, string $src, array $deps = array(), $version = false ) {
 	wp_script_modules()->register( $id, $src, $deps, $version );
 }
 
@@ -69,28 +75,33 @@ function wp_register_script_module( $id, $src, $deps = array(), $version = false
  *
  * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
  *                                    final import map.
- * @param string            $src      Optinal. Full URL of the script module, or path of the script module relative to
- *                                    the WordPress root directory. If it is provided and the script module has not
- *                                    been registered yet, it will be registered.
- * @param array             $deps     {
- *                                       Optional. List of dependencies.
- *                                       @type string|array $0... {
- *                                           An array of script module identifiers of the dependencies of this script
- *                                           module. The dependencies can be strings or arrays. If they are arrays,
- *                                           they need an `id` key with the script module identifier, and can contain
- *                                           an `import` key with either `static` or `dynamic`. By default,
- *                                           dependencies that don't contain an `import` key are considered static.
- *                                           @type string $id     The script module identifier.
- *                                           @type string $import Optional. Import type. May be either `static` or
- *                                                                `dynamic`. Defaults to `static`.
- *                                       }
- *                                   }
- * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
- *                                   It is added to the URL as a query string for cache busting purposes. If $version
- *                                   is set to false, the version number is the currently installed WordPress version.
- *                                   If $version is set to null, no version is added.
+	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
+	 *                                    to the WordPress root directory. If it is provided and the script module has
+	 *                                    not been registered yet, it will be registered.
+	 * @param array<string|array{
+	 *            id: string,
+	 *            import?: 'static'|'dynamic'
+	 *        }>                $deps     {
+	 *                                        Optional. List of dependencies.
+	 *
+	 *                                        @type string|array $0... {
+	 *                                            An array of script module identifiers of the dependencies of this script
+	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                            they need an `id` key with the script module identifier, and can contain
+	 *                                            an `import` key with either `static` or `dynamic`. By default,
+	 *                                            dependencies that don't contain an `import` key are considered static.
+	 *
+	 *                                            @type string $id     The script module identifier.
+	 *                                            @type string $import Optional. Import type. May be either `static` or
+	 *                                                                 `dynamic`. Defaults to `static`.
+	 *                                        }
+	 *                                    }
+	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
+	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                    is set to false, the version number is the currently installed WordPress version.
+	 *                                    If $version is set to null, no version is added.
  */
-function wp_enqueue_script_module( $id, $src = '', $deps = array(), $version = false ) {
+function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), $version = false ) {
 	wp_script_modules()->enqueue( $id, $src, $deps, $version );
 }
 
@@ -101,6 +112,6 @@ function wp_enqueue_script_module( $id, $src = '', $deps = array(), $version = f
  *
  * @param string $id The identifier of the script module.
  */
-function wp_dequeue_script_module( $id ) {
+function wp_dequeue_script_module( string $id ) {
 	wp_script_modules()->dequeue( $id );
 }

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -35,31 +35,31 @@ function wp_script_modules(): WP_Script_Modules {
  *
  * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
  *                                    final import map.
-	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
-	 *                                    to the WordPress root directory. If it is provided and the script module has
-	 *                                    not been registered yet, it will be registered.
-	 * @param array<string|array{
-	 *            id: string,
-	 *            import?: 'static'|'dynamic'
-	 *        }>                $deps     {
-	 *                                        Optional. List of dependencies.
-	 *
-	 *                                        @type string|array $0... {
-	 *                                            An array of script module identifiers of the dependencies of this script
-	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
-	 *                                            they need an `id` key with the script module identifier, and can contain
-	 *                                            an `import` key with either `static` or `dynamic`. By default,
-	 *                                            dependencies that don't contain an `import` key are considered static.
-	 *
-	 *                                            @type string $id     The script module identifier.
-	 *                                            @type string $import Optional. Import type. May be either `static` or
-	 *                                                                 `dynamic`. Defaults to `static`.
-	 *                                        }
-	 *                                    }
-	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
-	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
-	 *                                    is set to false, the version number is the currently installed WordPress version.
-	 *                                    If $version is set to null, no version is added.
+ * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
+ *                                    to the WordPress root directory. If it is provided and the script module has
+ *                                    not been registered yet, it will be registered.
+ * @param array<string|array{
+ *            id: string,
+ *            import?: 'static'|'dynamic'
+ *        }>                $deps     {
+ *                                        Optional. List of dependencies.
+ *
+ *                                        @type string|array $0... {
+ *                                            An array of script module identifiers of the dependencies of this script
+ *                                            module. The dependencies can be strings or arrays. If they are arrays,
+ *                                            they need an `id` key with the script module identifier, and can contain
+ *                                            an `import` key with either `static` or `dynamic`. By default,
+ *                                            dependencies that don't contain an `import` key are considered static.
+ *
+ *                                            @type string $id     The script module identifier.
+ *                                            @type string $import Optional. Import type. May be either `static` or
+ *                                                                 `dynamic`. Defaults to `static`.
+ *                                        }
+ *                                    }
+ * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
+ *                                    It is added to the URL as a query string for cache busting purposes. If $version
+ *                                    is set to false, the version number is the currently installed WordPress version.
+ *                                    If $version is set to null, no version is added.
  */
 function wp_register_script_module( string $id, string $src, array $deps = array(), $version = false ) {
 	wp_script_modules()->register( $id, $src, $deps, $version );
@@ -75,31 +75,31 @@ function wp_register_script_module( string $id, string $src, array $deps = array
  *
  * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
  *                                    final import map.
-	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
-	 *                                    to the WordPress root directory. If it is provided and the script module has
-	 *                                    not been registered yet, it will be registered.
-	 * @param array<string|array{
-	 *            id: string,
-	 *            import?: 'static'|'dynamic'
-	 *        }>                $deps     {
-	 *                                        Optional. List of dependencies.
-	 *
-	 *                                        @type string|array $0... {
-	 *                                            An array of script module identifiers of the dependencies of this script
-	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
-	 *                                            they need an `id` key with the script module identifier, and can contain
-	 *                                            an `import` key with either `static` or `dynamic`. By default,
-	 *                                            dependencies that don't contain an `import` key are considered static.
-	 *
-	 *                                            @type string $id     The script module identifier.
-	 *                                            @type string $import Optional. Import type. May be either `static` or
-	 *                                                                 `dynamic`. Defaults to `static`.
-	 *                                        }
-	 *                                    }
-	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
-	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
-	 *                                    is set to false, the version number is the currently installed WordPress version.
-	 *                                    If $version is set to null, no version is added.
+ * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
+ *                                    to the WordPress root directory. If it is provided and the script module has
+ *                                    not been registered yet, it will be registered.
+ * @param array<string|array{
+ *            id: string,
+ *            import?: 'static'|'dynamic'
+ *        }>                $deps     {
+ *                                        Optional. List of dependencies.
+ *
+ *                                        @type string|array $0... {
+ *                                            An array of script module identifiers of the dependencies of this script
+ *                                            module. The dependencies can be strings or arrays. If they are arrays,
+ *                                            they need an `id` key with the script module identifier, and can contain
+ *                                            an `import` key with either `static` or `dynamic`. By default,
+ *                                            dependencies that don't contain an `import` key are considered static.
+ *
+ *                                            @type string $id     The script module identifier.
+ *                                            @type string $import Optional. Import type. May be either `static` or
+ *                                                                 `dynamic`. Defaults to `static`.
+ *                                        }
+ *                                    }
+ * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
+ *                                    It is added to the URL as a query string for cache busting purposes. If $version
+ *                                    is set to false, the version number is the currently installed WordPress version.
+ *                                    If $version is set to null, no version is added.
  */
 function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), $version = false ) {
 	wp_script_modules()->enqueue( $id, $src, $deps, $version );

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -517,68 +517,6 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that it can print the enqueued script modules multiple times, and it
-	 * will only print the script modules that have not been printed before.
-	 *
-	 * @ticket 56313
-	 *
-	 * @covers ::register()
-	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_script_modules()
-	 */
-	public function test_print_enqueued_script_modules_can_be_called_multiple_times() {
-		$this->script_modules->register( 'foo', '/foo.js' );
-		$this->script_modules->register( 'bar', '/bar.js' );
-		$this->script_modules->enqueue( 'foo' );
-
-		$enqueued_script_modules = $this->get_enqueued_script_modules();
-		$this->assertCount( 1, $enqueued_script_modules );
-		$this->assertTrue( isset( $enqueued_script_modules['foo'] ) );
-
-		$this->script_modules->enqueue( 'bar' );
-
-		$enqueued_script_modules = $this->get_enqueued_script_modules();
-		$this->assertCount( 1, $enqueued_script_modules );
-		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
-
-		$enqueued_script_modules = $this->get_enqueued_script_modules();
-		$this->assertCount( 0, $enqueued_script_modules );
-	}
-
-	/**
-	 * Tests that it can print the preloaded script modules multiple times, and it
-	 * will only print the script modules that have not been printed before.
-	 *
-	 * @ticket 56313
-	 *
-	 * @covers ::register()
-	 * @covers ::enqueue()
-	 * @covers ::print_script_module_preloads()
-	 */
-	public function test_print_preloaded_script_modules_can_be_called_multiple_times() {
-		$this->script_modules->register( 'foo', '/foo.js', array( 'static-dep-1', 'static-dep-2' ) );
-		$this->script_modules->register( 'bar', '/bar.js', array( 'static-dep-3' ) );
-		$this->script_modules->register( 'static-dep-1', '/static-dep-1.js' );
-		$this->script_modules->register( 'static-dep-3', '/static-dep-3.js' );
-		$this->script_modules->enqueue( 'foo' );
-
-		$preloaded_script_modules = $this->get_preloaded_script_modules();
-		$this->assertCount( 1, $preloaded_script_modules );
-		$this->assertTrue( isset( $preloaded_script_modules['static-dep-1'] ) );
-
-		$this->script_modules->register( 'static-dep-2', '/static-dep-2.js' );
-		$this->script_modules->enqueue( 'bar' );
-
-		$preloaded_script_modules = $this->get_preloaded_script_modules();
-		$this->assertCount( 2, $preloaded_script_modules );
-		$this->assertTrue( isset( $preloaded_script_modules['static-dep-2'] ) );
-		$this->assertTrue( isset( $preloaded_script_modules['static-dep-3'] ) );
-
-		$preloaded_script_modules = $this->get_preloaded_script_modules();
-		$this->assertCount( 0, $preloaded_script_modules );
-	}
-
-	/**
 	 * Tests that a script module is not registered when calling enqueue without a
 	 * valid src.
 	 *

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -17,169 +17,163 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 *
 	 * @var WP_Script_Modules
 	 */
-	protected $modules;
+	protected $script_modules;
 
 	/**
 	 * Set up.
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->modules = new WP_Script_Modules();
+		$this->script_modules = new WP_Script_Modules();
 	}
 
 	/**
-	 * Gets a list of the enqueued modules.
+	 * Gets a list of the enqueued script modules.
 	 *
-	 * @return array Enqueued module URLs, keyed by module identifier.
+	 * @return array Enqueued script module URLs, keyed by script module identifier.
 	 */
-	public function get_enqueued_modules() {
-		$modules_markup   = get_echo( array( $this->modules, 'print_enqueued_modules' ) );
-		$p                = new WP_HTML_Tag_Processor( $modules_markup );
-		$enqueued_modules = array();
+	public function get_enqueued_script_modules() {
+		$script_modules_markup   = get_echo( array( $this->script_modules, 'print_enqueued_script_modules' ) );
+		$p                       = new WP_HTML_Tag_Processor( $script_modules_markup );
+		$enqueued_script_modules = array();
 
-		while ( $p->next_tag(
-			array(
-				'tag'    => 'SCRIPT',
-				'import' => 'module',
-			)
-		) ) {
-			$id                      = preg_replace( '/-js-module$/', '', $p->get_attribute( 'id' ) );
-			$enqueued_modules[ $id ] = $p->get_attribute( 'src' );
+		while ( $p->next_tag( array( 'tag' => 'SCRIPT' ) ) ) {
+			if ( 'module' === $p->get_attribute( 'type' ) ) {
+				$id                             = preg_replace( '/-js-module$/', '', $p->get_attribute( 'id' ) );
+				$enqueued_script_modules[ $id ] = $p->get_attribute( 'src' );
+			}
 		}
 
-		return $enqueued_modules;
+		return $enqueued_script_modules;
 	}
 
 	/**
-	 * Gets the modules listed in the import map.
+	 * Gets the script modules listed in the import map.
 	 *
-	 * @return array Import map entry URLs, keyed by module identifier.
+	 * @return array Import map entry URLs, keyed by script module identifier.
 	 */
 	public function get_import_map() {
-		$import_map_markup = get_echo( array( $this->modules, 'print_import_map' ) );
+		$import_map_markup = get_echo( array( $this->script_modules, 'print_import_map' ) );
 		preg_match( '/<script type="importmap" id="wp-importmap">.*?(\{.*\}).*?<\/script>/s', $import_map_markup, $import_map_string );
 		return json_decode( $import_map_string[1], true )['imports'];
 	}
 
 	/**
-	 * Gets a list of preloaded modules.
+	 * Gets a list of preloaded script modules.
 	 *
-	 * @return array Preloaded module URLs, keyed by module identifier.
+	 * @return array Preloaded script module URLs, keyed by script module identifier.
 	 */
-	public function get_preloaded_modules() {
-		$preloaded_markup  = get_echo( array( $this->modules, 'print_module_preloads' ) );
-		$p                 = new WP_HTML_Tag_Processor( $preloaded_markup );
-		$preloaded_modules = array();
+	public function get_preloaded_script_modules() {
+		$preloaded_markup         = get_echo( array( $this->script_modules, 'print_script_module_preloads' ) );
+		$p                        = new WP_HTML_Tag_Processor( $preloaded_markup );
+		$preloaded_script_modules = array();
 
-		while ( $p->next_tag(
-			array(
-				'tag' => 'LINK',
-				'rel' => 'modulepreload',
-			)
-		) ) {
-			$id                       = preg_replace( '/-js-modulepreload$/', '', $p->get_attribute( 'id' ) );
-			$preloaded_modules[ $id ] = $p->get_attribute( 'href' );
+		while ( $p->next_tag( array( 'tag' => 'LINK' ) ) ) {
+			if ( 'modulepreload' === $p->get_attribute( 'rel' ) ) {
+				$id                              = preg_replace( '/-js-modulepreload$/', '', $p->get_attribute( 'id' ) );
+				$preloaded_script_modules[ $id ] = $p->get_attribute( 'href' );
+			}
 		}
 
-		return $preloaded_modules;
+		return $preloaded_script_modules;
 	}
 
 	/**
-	 * Tests that a module gets enqueued correctly after being registered.
+	 * Tests that a script module gets enqueued correctly after being registered.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_modules()
+	 * @covers ::print_enqueued_script_modules()
 	 */
-	public function test_wp_enqueue_module() {
-		$this->modules->register( 'foo', '/foo.js' );
-		$this->modules->register( 'bar', '/bar.js' );
-		$this->modules->enqueue( 'foo' );
-		$this->modules->enqueue( 'bar' );
+	public function test_wp_enqueue_script_module() {
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->register( 'bar', '/bar.js' );
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->enqueue( 'bar' );
 
-		$enqueued_modules = $this->get_enqueued_modules();
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		$this->assertCount( 2, $enqueued_modules );
-		$this->assertStringStartsWith( '/foo.js', $enqueued_modules['foo'] );
-		$this->assertStringStartsWith( '/bar.js', $enqueued_modules['bar'] );
+		$this->assertCount( 2, $enqueued_script_modules );
+		$this->assertStringStartsWith( '/foo.js', $enqueued_script_modules['foo'] );
+		$this->assertStringStartsWith( '/bar.js', $enqueued_script_modules['bar'] );
 	}
 
 	/**
-	* Tests that a module can be dequeued after being enqueued.
+	* Tests that a script module can be dequeued after being enqueued.
 	*
 	* @ticket 56313
 	*
 	* @covers ::register()
 	* @covers ::enqueue()
 	* @covers ::dequeue()
-	* @covers ::print_enqueued_modules()
+	* @covers ::print_enqueued_script_modules()
 	*/
-	public function test_wp_dequeue_module() {
-		$this->modules->register( 'foo', '/foo.js' );
-		$this->modules->register( 'bar', '/bar.js' );
-		$this->modules->enqueue( 'foo' );
-		$this->modules->enqueue( 'bar' );
-		$this->modules->dequeue( 'foo' ); // Dequeued.
+	public function test_wp_dequeue_script_module() {
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->register( 'bar', '/bar.js' );
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->enqueue( 'bar' );
+		$this->script_modules->dequeue( 'foo' ); // Dequeued.
 
-		$enqueued_modules = $this->get_enqueued_modules();
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertFalse( isset( $enqueued_modules['foo'] ) );
-		$this->assertTrue( isset( $enqueued_modules['bar'] ) );
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
+		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
 	}
 
 	/**
-	* Tests that a module can be enqueued before it is registered, and will be
-	* handled correctly once registered.
+	* Tests that a script module can be enqueued before it is registered, and will
+	* be handled correctly once registered.
 	*
 	* @ticket 56313
 	*
 	* @covers ::register()
 	* @covers ::enqueue()
-	* @covers ::print_enqueued_modules()
+	* @covers ::print_enqueued_script_modules()
 	*/
-	public function test_wp_enqueue_module_works_before_register() {
-		$this->modules->enqueue( 'foo' );
-		$this->modules->register( 'foo', '/foo.js' );
-		$this->modules->enqueue( 'bar' ); // Not registered.
+	public function test_wp_enqueue_script_module_works_before_register() {
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->enqueue( 'bar' ); // Not registered.
 
-		$enqueued_modules = $this->get_enqueued_modules();
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertStringStartsWith( '/foo.js', $enqueued_modules['foo'] );
-		$this->assertFalse( isset( $enqueued_modules['bar'] ) );
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertStringStartsWith( '/foo.js', $enqueued_script_modules['foo'] );
+		$this->assertFalse( isset( $enqueued_script_modules['bar'] ) );
 	}
 
 	/**
-	 * Tests that a module can be dequeued before it is registered and ensures
-	 * that it is not enqueued after registration.
+	 * Tests that a script module can be dequeued before it is registered and
+	 * ensures that it is not enqueued after registration.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
 	 * @covers ::dequeue()
-	 * @covers ::print_enqueued_modules()
+	 * @covers ::print_enqueued_script_modules()
 	 */
-	public function test_wp_dequeue_module_works_before_register() {
-		$this->modules->enqueue( 'foo' );
-		$this->modules->enqueue( 'bar' );
-		$this->modules->dequeue( 'foo' );
-		$this->modules->register( 'foo', '/foo.js' );
-		$this->modules->register( 'bar', '/bar.js' );
+	public function test_wp_dequeue_script_module_works_before_register() {
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->enqueue( 'bar' );
+		$this->script_modules->dequeue( 'foo' );
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->register( 'bar', '/bar.js' );
 
-		$enqueued_modules = $this->get_enqueued_modules();
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertFalse( isset( $enqueued_modules['foo'] ) );
-		$this->assertTrue( isset( $enqueued_modules['bar'] ) );
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
+		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
 	}
 
 	/**
 	 * Tests that dependencies for a registered module are added to the import map
-	 * when the module is enqueued.
+	 * when the script module is enqueued.
 	 *
 	 * @ticket 56313
 	 *
@@ -188,10 +182,10 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 * @covers ::print_import_map()
 	 */
 	public function test_wp_import_map_dependencies() {
-		$this->modules->register( 'foo', '/foo.js', array( 'dep' ) );
-		$this->modules->register( 'dep', '/dep.js' );
-		$this->modules->register( 'no-dep', '/no-dep.js' );
-		$this->modules->enqueue( 'foo' );
+		$this->script_modules->register( 'foo', '/foo.js', array( 'dep' ) );
+		$this->script_modules->register( 'dep', '/dep.js' );
+		$this->script_modules->register( 'no-dep', '/no-dep.js' );
+		$this->script_modules->enqueue( 'foo' );
 
 		$import_map = $this->get_import_map();
 
@@ -202,7 +196,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 
 	/**
 	 * Tests that dependencies are not duplicated in the import map when multiple
-	 * modules require the same dependency.
+	 * script modules require the same dependency.
 	 *
 	 * @ticket 56313
 	 *
@@ -211,11 +205,11 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 * @covers ::print_import_map()
 	 */
 	public function test_wp_import_map_no_duplicate_dependencies() {
-		$this->modules->register( 'foo', '/foo.js', array( 'dep' ) );
-		$this->modules->register( 'bar', '/bar.js', array( 'dep' ) );
-		$this->modules->register( 'dep', '/dep.js' );
-		$this->modules->enqueue( 'foo' );
-		$this->modules->enqueue( 'bar' );
+		$this->script_modules->register( 'foo', '/foo.js', array( 'dep' ) );
+		$this->script_modules->register( 'bar', '/bar.js', array( 'dep' ) );
+		$this->script_modules->register( 'dep', '/dep.js' );
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->enqueue( 'bar' );
 
 		$import_map = $this->get_import_map();
 
@@ -234,7 +228,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 * @covers ::print_import_map()
 	 */
 	public function test_wp_import_map_recursive_dependencies() {
-		$this->modules->register(
+		$this->script_modules->register(
 			'foo',
 			'/foo.js',
 			array(
@@ -245,7 +239,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 				),
 			)
 		);
-		$this->modules->register(
+		$this->script_modules->register(
 			'static-dep',
 			'/static-dep.js',
 			array(
@@ -259,11 +253,11 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 				),
 			)
 		);
-		$this->modules->register( 'dynamic-dep', '/dynamic-dep.js' );
-		$this->modules->register( 'nested-static-dep', '/nested-static-dep.js' );
-		$this->modules->register( 'nested-dynamic-dep', '/nested-dynamic-dep.js' );
-		$this->modules->register( 'no-dep', '/no-dep.js' );
-		$this->modules->enqueue( 'foo' );
+		$this->script_modules->register( 'dynamic-dep', '/dynamic-dep.js' );
+		$this->script_modules->register( 'nested-static-dep', '/nested-static-dep.js' );
+		$this->script_modules->register( 'nested-dynamic-dep', '/nested-dynamic-dep.js' );
+		$this->script_modules->register( 'no-dep', '/no-dep.js' );
+		$this->script_modules->enqueue( 'foo' );
 
 		$import_map = $this->get_import_map();
 
@@ -285,10 +279,10 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 * @covers ::print_import_map()
 	 */
 	public function test_wp_import_map_doesnt_print_if_no_dependencies() {
-		$this->modules->register( 'foo', '/foo.js' ); // No deps.
-		$this->modules->enqueue( 'foo' );
+		$this->script_modules->register( 'foo', '/foo.js' ); // No deps.
+		$this->script_modules->enqueue( 'foo' );
 
-		$import_map_markup = get_echo( array( $this->modules, 'print_import_map' ) );
+		$import_map_markup = get_echo( array( $this->script_modules, 'print_import_map' ) );
 
 		$this->assertEmpty( $import_map_markup );
 	}
@@ -301,10 +295,10 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_module_preloads()
+	 * @covers ::print_script_module_preloads()
 	 */
 	public function test_wp_enqueue_preloaded_static_dependencies() {
-		$this->modules->register(
+		$this->script_modules->register(
 			'foo',
 			'/foo.js',
 			array(
@@ -315,7 +309,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 				),
 			)
 		);
-		$this->modules->register(
+		$this->script_modules->register(
 			'static-dep',
 			'/static-dep.js',
 			array(
@@ -329,20 +323,20 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 				),
 			)
 		);
-		$this->modules->register( 'dynamic-dep', '/dynamic-dep.js' );
-		$this->modules->register( 'nested-static-dep', '/nested-static-dep.js' );
-		$this->modules->register( 'nested-dynamic-dep', '/nested-dynamic-dep.js' );
-		$this->modules->register( 'no-dep', '/no-dep.js' );
-		$this->modules->enqueue( 'foo' );
+		$this->script_modules->register( 'dynamic-dep', '/dynamic-dep.js' );
+		$this->script_modules->register( 'nested-static-dep', '/nested-static-dep.js' );
+		$this->script_modules->register( 'nested-dynamic-dep', '/nested-dynamic-dep.js' );
+		$this->script_modules->register( 'no-dep', '/no-dep.js' );
+		$this->script_modules->enqueue( 'foo' );
 
-		$preloaded_modules = $this->get_preloaded_modules();
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
 
-		$this->assertCount( 2, $preloaded_modules );
-		$this->assertStringStartsWith( '/static-dep.js', $preloaded_modules['static-dep'] );
-		$this->assertStringStartsWith( '/nested-static-dep.js', $preloaded_modules['nested-static-dep'] );
-		$this->assertFalse( isset( $preloaded_modules['no-dep'] ) );
-		$this->assertFalse( isset( $preloaded_modules['dynamic-dep'] ) );
-		$this->assertFalse( isset( $preloaded_modules['nested-dynamic-dep'] ) );
+		$this->assertCount( 2, $preloaded_script_modules );
+		$this->assertStringStartsWith( '/static-dep.js', $preloaded_script_modules['static-dep'] );
+		$this->assertStringStartsWith( '/nested-static-dep.js', $preloaded_script_modules['nested-static-dep'] );
+		$this->assertFalse( isset( $preloaded_script_modules['no-dep'] ) );
+		$this->assertFalse( isset( $preloaded_script_modules['dynamic-dep'] ) );
+		$this->assertFalse( isset( $preloaded_script_modules['nested-dynamic-dep'] ) );
 	}
 
 	/**
@@ -352,10 +346,10 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_module_preloads()
+	 * @covers ::print_script_module_preloads()
 	 */
 	public function test_wp_dont_preload_static_dependencies_of_dynamic_dependencies() {
-		$this->modules->register(
+		$this->script_modules->register(
 			'foo',
 			'/foo.js',
 			array(
@@ -366,32 +360,32 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 				),
 			)
 		);
-		$this->modules->register( 'static-dep', '/static-dep.js' );
-		$this->modules->register( 'dynamic-dep', '/dynamic-dep.js', array( 'nested-static-dep' ) );
-		$this->modules->register( 'nested-static-dep', '/nested-static-dep.js' );
-		$this->modules->register( 'no-dep', '/no-dep.js' );
-		$this->modules->enqueue( 'foo' );
+		$this->script_modules->register( 'static-dep', '/static-dep.js' );
+		$this->script_modules->register( 'dynamic-dep', '/dynamic-dep.js', array( 'nested-static-dep' ) );
+		$this->script_modules->register( 'nested-static-dep', '/nested-static-dep.js' );
+		$this->script_modules->register( 'no-dep', '/no-dep.js' );
+		$this->script_modules->enqueue( 'foo' );
 
-		$preloaded_modules = $this->get_preloaded_modules();
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
 
-		$this->assertCount( 1, $preloaded_modules );
-		$this->assertStringStartsWith( '/static-dep.js', $preloaded_modules['static-dep'] );
-		$this->assertFalse( isset( $preloaded_modules['dynamic-dep'] ) );
-		$this->assertFalse( isset( $preloaded_modules['nested-static-dep'] ) );
-		$this->assertFalse( isset( $preloaded_modules['no-dep'] ) );
+		$this->assertCount( 1, $preloaded_script_modules );
+		$this->assertStringStartsWith( '/static-dep.js', $preloaded_script_modules['static-dep'] );
+		$this->assertFalse( isset( $preloaded_script_modules['dynamic-dep'] ) );
+		$this->assertFalse( isset( $preloaded_script_modules['nested-static-dep'] ) );
+		$this->assertFalse( isset( $preloaded_script_modules['no-dep'] ) );
 	}
 
 	/**
-	 * Tests that preloaded dependencies don't include enqueued modules.
+	 * Tests that preloaded dependencies don't include enqueued script modules.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_module_preloads()
+	 * @covers ::print_script_module_preloads()
 	 */
-	public function test_wp_preloaded_dependencies_filter_enqueued_modules() {
-		$this->modules->register(
+	public function test_wp_preloaded_dependencies_filter_enqueued_script_modules() {
+		$this->script_modules->register(
 			'foo',
 			'/foo.js',
 			array(
@@ -399,21 +393,21 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 				'enqueued-dep',
 			)
 		);
-		$this->modules->register( 'dep', '/dep.js' );
-		$this->modules->register( 'enqueued-dep', '/enqueued-dep.js' );
-		$this->modules->enqueue( 'foo' );
-		$this->modules->enqueue( 'enqueued-dep' ); // Not preloaded.
+		$this->script_modules->register( 'dep', '/dep.js' );
+		$this->script_modules->register( 'enqueued-dep', '/enqueued-dep.js' );
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->enqueue( 'enqueued-dep' ); // Not preloaded.
 
-		$preloaded_modules = $this->get_preloaded_modules();
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
 
-		$this->assertCount( 1, $preloaded_modules );
-		$this->assertTrue( isset( $preloaded_modules['dep'] ) );
-		$this->assertFalse( isset( $preloaded_modules['enqueued-dep'] ) );
+		$this->assertCount( 1, $preloaded_script_modules );
+		$this->assertTrue( isset( $preloaded_script_modules['dep'] ) );
+		$this->assertFalse( isset( $preloaded_script_modules['enqueued-dep'] ) );
 	}
 
 	/**
-	 * Tests that enqueued modules with dependants correctly add both the module
-	 * and its dependencies to the import map.
+	 * Tests that enqueued script modules with dependants correctly add both the
+	 * script module and its dependencies to the import map.
 	 *
 	 * @ticket 56313
 	 *
@@ -421,8 +415,8 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 * @covers ::enqueue()
 	 * @covers ::print_import_map()
 	 */
-	public function test_wp_enqueued_modules_with_dependants_add_import_map() {
-		$this->modules->register(
+	public function test_wp_enqueued_script_modules_with_dependants_add_import_map() {
+		$this->script_modules->register(
 			'foo',
 			'/foo.js',
 			array(
@@ -430,10 +424,10 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 				'enqueued-dep',
 			)
 		);
-		$this->modules->register( 'dep', '/dep.js' );
-		$this->modules->register( 'enqueued-dep', '/enqueued-dep.js' );
-		$this->modules->enqueue( 'foo' );
-		$this->modules->enqueue( 'enqueued-dep' ); // Also in the import map.
+		$this->script_modules->register( 'dep', '/dep.js' );
+		$this->script_modules->register( 'enqueued-dep', '/enqueued-dep.js' );
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->enqueue( 'enqueued-dep' ); // Also in the import map.
 
 		$import_map = $this->get_import_map();
 
@@ -451,7 +445,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	 * @covers ::get_versioned_src()
 	 */
 	public function test_get_versioned_src() {
-		$get_versioned_src = new ReflectionMethod( $this->modules, 'get_versioned_src' );
+		$get_versioned_src = new ReflectionMethod( $this->script_modules, 'get_versioned_src' );
 		$get_versioned_src->setAccessible( true );
 
 		$module_with_version = array(
@@ -459,7 +453,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 			'version' => '1.0',
 		);
 
-		$result = $get_versioned_src->invoke( $this->modules, $module_with_version );
+		$result = $get_versioned_src->invoke( $this->script_modules, $module_with_version );
 		$this->assertEquals( 'http://example.com/module.js?ver=1.0', $result );
 
 		$module_without_version = array(
@@ -467,7 +461,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 			'version' => null,
 		);
 
-		$result = $get_versioned_src->invoke( $this->modules, $module_without_version );
+		$result = $get_versioned_src->invoke( $this->script_modules, $module_without_version );
 		$this->assertEquals( 'http://example.com/module.js', $result );
 
 		$module_with_wp_version = array(
@@ -475,7 +469,7 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 			'version' => false,
 		);
 
-		$result = $get_versioned_src->invoke( $this->modules, $module_with_wp_version );
+		$result = $get_versioned_src->invoke( $this->script_modules, $module_with_wp_version );
 		$this->assertEquals( 'http://example.com/module.js?ver=' . get_bloginfo( 'version' ), $result );
 
 		$module_with_existing_query_string = array(
@@ -483,25 +477,25 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 			'version' => '1.0',
 		);
 
-		$result = $get_versioned_src->invoke( $this->modules, $module_with_existing_query_string );
+		$result = $get_versioned_src->invoke( $this->script_modules, $module_with_existing_query_string );
 		$this->assertEquals( 'http://example.com/module.js?foo=bar&ver=1.0', $result );
 	}
 
 	/**
 	 * Tests that the correct version is propagated to the import map, enqueued
-	 * modules and preloaded modules.
+	 * script modules and preloaded script modules.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_modules()
+	 * @covers ::print_enqueued_script_modules()
 	 * @covers ::print_import_map()
-	 * @covers ::print_module_preloads()
+	 * @covers ::print_script_module_preloads()
 	 * @covers ::get_version_query_string()
 	 */
 	public function test_version_is_propagated_correctly() {
-		$this->modules->register(
+		$this->script_modules->register(
 			'foo',
 			'/foo.js',
 			array(
@@ -509,160 +503,162 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 			),
 			'1.0'
 		);
-		$this->modules->register( 'dep', '/dep.js', array(), '2.0' );
-		$this->modules->enqueue( 'foo' );
+		$this->script_modules->register( 'dep', '/dep.js', array(), '2.0' );
+		$this->script_modules->enqueue( 'foo' );
 
-		$enqueued_modules = $this->get_enqueued_modules();
-		$this->assertEquals( '/foo.js?ver=1.0', $enqueued_modules['foo'] );
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+		$this->assertEquals( '/foo.js?ver=1.0', $enqueued_script_modules['foo'] );
 
 		$import_map = $this->get_import_map();
 		$this->assertEquals( '/dep.js?ver=2.0', $import_map['dep'] );
 
-		$preloaded_modules = $this->get_preloaded_modules();
-		$this->assertEquals( '/dep.js?ver=2.0', $preloaded_modules['dep'] );
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
+		$this->assertEquals( '/dep.js?ver=2.0', $preloaded_script_modules['dep'] );
 	}
 
 	/**
-	 * Tests that it can print the enqueued modules multiple times, and it will
-	 * only print the modules that have not been printed before.
+	 * Tests that it can print the enqueued script modules multiple times, and it
+	 * will only print the script modules that have not been printed before.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_modules()
+	 * @covers ::print_enqueued_script_modules()
 	 */
-	public function test_print_enqueued_modules_can_be_called_multiple_times() {
-		$this->modules->register( 'foo', '/foo.js' );
-		$this->modules->register( 'bar', '/bar.js' );
-		$this->modules->enqueue( 'foo' );
+	public function test_print_enqueued_script_modules_can_be_called_multiple_times() {
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->register( 'bar', '/bar.js' );
+		$this->script_modules->enqueue( 'foo' );
 
-		$enqueued_modules = $this->get_enqueued_modules();
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertTrue( isset( $enqueued_modules['foo'] ) );
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertTrue( isset( $enqueued_script_modules['foo'] ) );
 
-		$this->modules->enqueue( 'bar' );
+		$this->script_modules->enqueue( 'bar' );
 
-		$enqueued_modules = $this->get_enqueued_modules();
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertTrue( isset( $enqueued_modules['bar'] ) );
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
 
-		$enqueued_modules = $this->get_enqueued_modules();
-		$this->assertCount( 0, $enqueued_modules );
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+		$this->assertCount( 0, $enqueued_script_modules );
 	}
 
 	/**
-	 * Tests that it can print the preloaded modules multiple times, and it will
-	 * only print the modules that have not been printed before.
+	 * Tests that it can print the preloaded script modules multiple times, and it
+	 * will only print the script modules that have not been printed before.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_module_preloads()
+	 * @covers ::print_script_module_preloads()
 	 */
-	public function test_print_preloaded_modules_can_be_called_multiple_times() {
-		$this->modules->register( 'foo', '/foo.js', array( 'static-dep-1', 'static-dep-2' ) );
-		$this->modules->register( 'bar', '/bar.js', array( 'static-dep-3' ) );
-		$this->modules->register( 'static-dep-1', '/static-dep-1.js' );
-		$this->modules->register( 'static-dep-3', '/static-dep-3.js' );
-		$this->modules->enqueue( 'foo' );
+	public function test_print_preloaded_script_modules_can_be_called_multiple_times() {
+		$this->script_modules->register( 'foo', '/foo.js', array( 'static-dep-1', 'static-dep-2' ) );
+		$this->script_modules->register( 'bar', '/bar.js', array( 'static-dep-3' ) );
+		$this->script_modules->register( 'static-dep-1', '/static-dep-1.js' );
+		$this->script_modules->register( 'static-dep-3', '/static-dep-3.js' );
+		$this->script_modules->enqueue( 'foo' );
 
-		$preloaded_modules = $this->get_preloaded_modules();
-		$this->assertCount( 1, $preloaded_modules );
-		$this->assertTrue( isset( $preloaded_modules['static-dep-1'] ) );
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
+		$this->assertCount( 1, $preloaded_script_modules );
+		$this->assertTrue( isset( $preloaded_script_modules['static-dep-1'] ) );
 
-		$this->modules->register( 'static-dep-2', '/static-dep-2.js' );
-		$this->modules->enqueue( 'bar' );
+		$this->script_modules->register( 'static-dep-2', '/static-dep-2.js' );
+		$this->script_modules->enqueue( 'bar' );
 
-		$preloaded_modules = $this->get_preloaded_modules();
-		$this->assertCount( 2, $preloaded_modules );
-		$this->assertTrue( isset( $preloaded_modules['static-dep-2'] ) );
-		$this->assertTrue( isset( $preloaded_modules['static-dep-3'] ) );
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
+		$this->assertCount( 2, $preloaded_script_modules );
+		$this->assertTrue( isset( $preloaded_script_modules['static-dep-2'] ) );
+		$this->assertTrue( isset( $preloaded_script_modules['static-dep-3'] ) );
 
-		$preloaded_modules = $this->get_preloaded_modules();
-		$this->assertCount( 0, $preloaded_modules );
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
+		$this->assertCount( 0, $preloaded_script_modules );
 	}
 
 	/**
-	 * Tests that a module is not registered when calling enqueue without a valid
+	 * Tests that a script module is not registered when calling enqueue without a
+	 * valid src.
+	 *
+	 * @ticket 56313
+	 *
+	 * @covers ::enqueue()
+	 * @covers ::print_enqueued_script_modules()
+	 */
+	public function test_wp_enqueue_script_module_doesnt_register_without_a_valid_src() {
+		$this->script_modules->enqueue( 'foo' );
+
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 0, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
+	}
+
+	/**
+	 * Tests that a script module is registered when calling enqueue with a valid
 	 * src.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_modules()
+	 * @covers ::print_enqueued_script_modules()
 	 */
-	public function test_wp_enqueue_module_doesnt_register_without_a_valid_src() {
-		$this->modules->enqueue( 'foo' );
+	public function test_wp_enqueue_script_module_registers_with_valid_src() {
+		$this->script_modules->enqueue( 'foo', '/foo.js' );
 
-		$enqueued_modules = $this->get_enqueued_modules();
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		$this->assertCount( 0, $enqueued_modules );
-		$this->assertFalse( isset( $enqueued_modules['foo'] ) );
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertStringStartsWith( '/foo.js', $enqueued_script_modules['foo'] );
 	}
 
 	/**
-	 * Tests that a module is registered when calling enqueue with a valid src.
+	 * Tests that a script module is registered when calling enqueue with a valid
+	 * src the second time.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_modules()
+	 * @covers ::print_enqueued_script_modules()
 	 */
-	public function test_wp_enqueue_module_registers_with_valid_src() {
-		$this->modules->enqueue( 'foo', '/foo.js' );
+	public function test_wp_enqueue_script_module_registers_with_valid_src_the_second_time() {
+		$this->script_modules->enqueue( 'foo' ); // Not valid src.
 
-		$enqueued_modules = $this->get_enqueued_modules();
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertStringStartsWith( '/foo.js', $enqueued_modules['foo'] );
+		$this->assertCount( 0, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
+
+		$this->script_modules->enqueue( 'foo', '/foo.js' ); // Valid src.
+
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertStringStartsWith( '/foo.js', $enqueued_script_modules['foo'] );
 	}
 
 	/**
-	 * Tests that a module is registered when calling enqueue with a valid src the
-	 * second time.
-	 *
-	 * @ticket 56313
-	 *
-	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_modules()
-	 */
-	public function test_wp_enqueue_module_registers_with_valid_src_the_second_time() {
-		$this->modules->enqueue( 'foo' ); // Not valid src.
-
-		$enqueued_modules = $this->get_enqueued_modules();
-
-		$this->assertCount( 0, $enqueued_modules );
-		$this->assertFalse( isset( $enqueued_modules['foo'] ) );
-
-		$this->modules->enqueue( 'foo', '/foo.js' ); // Valid src.
-
-		$enqueued_modules = $this->get_enqueued_modules();
-
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertStringStartsWith( '/foo.js', $enqueued_modules['foo'] );
-	}
-
-	/**
-	 * Tests that a module is registered with all the params when calling enqueue.
+	 * Tests that a script module is registered with all the params when calling
+	 * enqueue.
 	 *
 	 * @ticket 56313
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_modules()
+	 * @covers ::print_enqueued_script_modules()
 	 * @covers ::print_import_map()
 	 */
-	public function test_wp_enqueue_module_registers_all_params() {
-		$this->modules->enqueue( 'foo', '/foo.js', array( 'dep' ), '1.0' );
-		$this->modules->register( 'dep', '/dep.js' );
+	public function test_wp_enqueue_script_module_registers_all_params() {
+		$this->script_modules->enqueue( 'foo', '/foo.js', array( 'dep' ), '1.0' );
+		$this->script_modules->register( 'dep', '/dep.js' );
 
-		$enqueued_modules = $this->get_enqueued_modules();
-		$import_map       = $this->get_import_map();
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+		$import_map              = $this->get_import_map();
 
-		$this->assertCount( 1, $enqueued_modules );
-		$this->assertEquals( '/foo.js?ver=1.0', $enqueued_modules['foo'] );
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertEquals( '/foo.js?ver=1.0', $enqueued_script_modules['foo'] );
 		$this->assertCount( 1, $import_map );
 		$this->assertStringStartsWith( '/dep.js', $import_map['dep'] );
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60240

---

**!! This is built on top of https://github.com/WordPress/wordpress-develop/pull/5869**. For that reason it's still a local PR. I will rebase it and open a PR in the `WordPress/wordpress-develop` once https://github.com/WordPress/wordpress-develop/pull/5869 is merged.

## What

Moves the script module prints to the footer in classic themes. It also removes the ability to call the print functions more than once because it's now unnecessary.

## Why

In the ticket that introduced the Script Modules API ([#56313](https://core.trac.wordpress.org/ticket/56313 "#56313: enhancement: Add the ability to handle ES Modules and Import Maps (reopened)")), I added a logic that prints as many enqueued and preloads as possible in the head, then prints the remaining ones in the footer and includes the import map. I explain my reasoning [​in this comment](https://github.com/WordPress/wordpress-develop/pull/5818#discussion_r1446384970).

But [@cbravobernal](https://profiles.wordpress.org/cbravobernal) realized that [import maps fail if they appear after the modules](https://github.com/WordPress/gutenberg/pull/57778#discussion_r1449482982). That means that there's no other way but printing the import map first, and then all the modules and preloads (yes, preloads also fail!). So we need to check if we are on a classic or block theme, and if we are in a classic theme, move everything to the footer.

## How

By leveraging `wp_is_block_theme()` and moving everything to the footer in classic themes:

```php
public function add_hooks() {
  $position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
  add_action( $position, array( $this, 'print_import_map' ) );
  add_action( $position, array( $this, 'print_enqueued_modules' ) );
  add_action( $position, array( $this, 'print_module_preloads' ) );
}
```

### Additional comments

@westonruter mentioned that we could optimize this in the future if we have a way to filter the output before sending the response to the client: 

- https://github.com/WordPress/gutenberg/pull/57778#discussion_r1450806250